### PR TITLE
Fix outputting bam file when running filtersam in single-processor mode.

### DIFF
--- a/filtersam/filtersam.py
+++ b/filtersam/filtersam.py
@@ -104,7 +104,7 @@ def filterSAMbyIdentity(input_path: Path, output_path: Path = None,
     equal or above identity_cutoff value.
     """
     input_path = Path(input_path)
-    file_ext = re.search('.(s|b)am', input_path.as_posix()).group()
+    file_ext = input_path.suffix
     if output_path is None:
         output_path = (f'{input_path.as_posix().split(file_ext)[0]}'
                        f'.identity_filtered_at_{identity_cutoff}{file_ext}')
@@ -130,7 +130,7 @@ def filterSAMbyPercentMatched(input_path: Path, output_path: Path = None,
     the total query length.
     """
     input_path = Path(input_path)
-    file_ext = re.search('.(s|b)am', input_path.as_posix()).group()
+    file_ext = input_path.suffix
     if output_path is None:
         output_path = (f'{input_path.as_posix().split(file_ext)[0]}'
                        f'_matched_filtered_at_{matched_cutoff}{file_ext}') 

--- a/filtersam/filtersam.py
+++ b/filtersam/filtersam.py
@@ -109,9 +109,10 @@ def filterSAMbyIdentity(input_path: Path, output_path: Path = None,
         output_path = (f'{input_path.as_posix().split(file_ext)[0]}'
                        f'.identity_filtered_at_{identity_cutoff}{file_ext}')
     output_path = Path(output_path)
+    mode = 'w' if file_ext == '.sam' else 'wb'
     save = pysam.set_verbosity(0)
     samfile = pysam.AlignmentFile(input_path, 'r')
-    filtered_sam = pysam.AlignmentFile(output_path, 'w', template=samfile)
+    filtered_sam = pysam.AlignmentFile(output_path, mode, template=samfile)
     pysam.set_verbosity(save)                                      
     for segment in samfile:
         if (has_MD_tag(segment) and percent_identity(segment) >= identity_cutoff):
@@ -134,9 +135,10 @@ def filterSAMbyPercentMatched(input_path: Path, output_path: Path = None,
         output_path = (f'{input_path.as_posix().split(file_ext)[0]}'
                        f'_matched_filtered_at_{matched_cutoff}{file_ext}') 
     output_path = Path(output_path)
+    mode = 'w' if file_ext == '.sam' else 'wb'
     save = pysam.set_verbosity(0)
     samfile = pysam.AlignmentFile(input_path, 'r')
-    filtered_sam = pysam.AlignmentFile(output_path, 'w', template=samfile)
+    filtered_sam = pysam.AlignmentFile(output_path, mode, template=samfile)
     pysam.set_verbosity(save)
     for segment in samfile:
         if (has_MD_tag(segment) and percent_matched(segment) >= matched_cutoff):

--- a/filtersam/filtersam.py
+++ b/filtersam/filtersam.py
@@ -109,7 +109,8 @@ def filterSAMbyIdentity(input_path: Path, output_path: Path = None,
         output_path = (f'{input_path.as_posix().split(file_ext)[0]}'
                        f'.identity_filtered_at_{identity_cutoff}{file_ext}')
     output_path = Path(output_path)
-    mode = 'w' if file_ext == '.sam' else 'wb'
+    output_ext = output_path.suffix
+    mode = 'w' if output_ext == '.sam' else 'wb'
     save = pysam.set_verbosity(0)
     samfile = pysam.AlignmentFile(input_path, 'r')
     filtered_sam = pysam.AlignmentFile(output_path, mode, template=samfile)
@@ -135,7 +136,8 @@ def filterSAMbyPercentMatched(input_path: Path, output_path: Path = None,
         output_path = (f'{input_path.as_posix().split(file_ext)[0]}'
                        f'_matched_filtered_at_{matched_cutoff}{file_ext}') 
     output_path = Path(output_path)
-    mode = 'w' if file_ext == '.sam' else 'wb'
+    output_ext = output_path.suffix
+    mode = 'w' if output_ext == '.sam' else 'wb'
     save = pysam.set_verbosity(0)
     samfile = pysam.AlignmentFile(input_path, 'r')
     filtered_sam = pysam.AlignmentFile(output_path, mode, template=samfile)

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
-from setuptools import setup, find_packages
 from os import path
 
+from setuptools import find_packages
+from setuptools import setup
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), 'r', encoding='utf-8') as f:
     long_description = f.read()
 
-DESCRIPTION = 'Tools to filter sam o bam files by percent identity or percent of matched sequence',
-LONG_DESCRIPTION = long_description,
+DESCRIPTION = 'Tools to filter sam o bam files by percent identity or percent of matched sequence'
+LONG_DESCRIPTION = long_description
 LONG_DESCRIPTION_CONTENT_TYPE = 'text/markdown'
 NAME = 'filtersam'
 AUTHOR = "Semidán Robaina Estévez, 2021-2022"


### PR DESCRIPTION
When running in single processor mode (not specifying `-p`), `filtersam` will always output a `sam` file, whether you ask for a `.sam` or `.bam` extension. This is because the output file is always opened in write mode and not in write binary, which is necessary for `pysam` to output a `bam` file (see https://github.com/pysam-developers/pysam/blob/master/pysam/libcalignmentfile.pyx#L632).

There was also an issue in the determination of the input file extension.