### PR TITLE
Treat `-p 1` as single-processor mode + add test suite & CI

### DIFF
--- a/filtersam/filtersam.py
+++ b/filtersam/filtersam.py
@@ -166,7 +166,7 @@ def filterSAM(input_path: Path, output_path: Path = None,
     if not (cutoff >=0 and cutoff <= 100):
         raise ValueError('Cutoff value must be between 0 and 100.')
     
-    if n_processes is None:
+    if n_processes is None or n_processes <= 1:
         filter_method(input_path, output_path, cutoff)
     else:
         if '.sam' in input_path.name:


### PR DESCRIPTION
## Summary

Two related things:

### 1. `-p 1` behaves like single-processor mode (fixes part of #3)
When `n_processes` was set (including `1`), `filterSAM` routed through the parallel branch, which first splits the input BAM via `parallelBAM` (a full name-sort + SAM round-trip + recompression — an expensive serial step) before any parallel work. With `-p 1` this cost buys zero parallelism and surprised workflow managers (e.g. Nextflow) that always pass an explicit process count.

`n_processes <= 1` is now treated the same as `None`:

```python
if n_processes is None or n_processes <= 1:
    filter_method(input_path, output_path, cutoff)
```

### 2. Test suite + CI
A 32-test pytest battery plus a GitHub Actions workflow. Coverage: metric helpers against segments with known values; `filterSAMbyIdentity`/`filterSAMbyPercentMatched` retention at several cutoffs on SAM and BAM input with MD-less reads dropped; output-format selection (SAM text, BAM binary, output extension wins over input — guards the merged single-process BAM-output fix); default output-path naming for `sam`/`bam` filenames; and `filterSAM` dispatch (validation errors, single-vs-parallel routing incl. `n_processes <= 1` never splitting, and an end-to-end parallel run matching serial).

## Scope
Quick, self-contained part of #3. The deeper split-step inefficiency lives in `parallelBAM` and is tracked in Robaina/parallelBAM#2.