### PR TITLE
Skip name-sort (perf) + rename to filtersam-tools + PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 
 # Publishes the package to PyPI when a GitHub Release is published.
 # Uses PyPI Trusted Publishing (OIDC) — no API token is stored in the repo.
-# The matching publisher must be configured on PyPI for project "filter-sam"
+# The matching publisher must be configured on PyPI for project "filtersam-tools"
 # with this workflow filename (publish.yml) and environment name (pypi).
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: publish
+
+# Publishes the package to PyPI when a GitHub Release is published.
+# Uses PyPI Trusted Publishing (OIDC) — no API token is stored in the repo.
+# The matching publisher must be configured on PyPI for project "filter-sam"
+# with this workflow filename (publish.yml) and environment name (pypi).
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pysam numpy pytest
-          # parallelbam>=0.0.20 (sort_by_name support) is not on PyPI yet;
-          # install from the repo until it is released, then switch back to PyPI.
-          python -m pip install "parallelbam @ git+https://github.com/Robaina/parallelBAM.git@main"
+          # parallel-bam>=0.0.20 (sort_by_name support) is not on PyPI yet;
+          # install from the repo until it is released, then switch to:
+          #   python -m pip install "parallel-bam>=0.0.20"
+          python -m pip install "git+https://github.com/Robaina/parallelBAM.git@main"
           python -m pip install -e . --no-deps
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pysam numpy pytest
-          # parallel-bam>=0.0.20 (sort_by_name support) is not on PyPI yet;
+          # parallelbam-tools>=0.0.20 (sort_by_name support) is not on PyPI yet;
           # install from the repo until it is released, then switch to:
-          #   python -m pip install "parallel-bam>=0.0.20"
+          #   python -m pip install "parallelbam-tools>=0.0.20"
           python -m pip install "git+https://github.com/Robaina/parallelBAM.git@main"
           python -m pip install -e . --no-deps
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pysam numpy pytest parallelbam
+          python -m pip install pysam numpy pytest
+          # parallelbam>=0.0.20 (sort_by_name support) is not on PyPI yet;
+          # install from the repo until it is released, then switch back to PyPI.
+          python -m pip install "parallelbam @ git+https://github.com/Robaina/parallelBAM.git@main"
           python -m pip install -e . --no-deps
 
       - name: Run tests

--- a/filtersam/filtersam.py
+++ b/filtersam/filtersam.py
@@ -173,6 +173,10 @@ def filterSAM(input_path: Path, output_path: Path = None,
             print('Converting sam file to bam for processing')
             input_path = Path(input_path.as_posix().replace('.sam', '.bam'))
             sam2bam(input_path)
+        # Both filters evaluate each segment independently, so the chunks do
+        # not need reads grouped by query name. Skipping parallelbam's
+        # name-sort avoids a full serial pass over the file (see #3).
         parallelizeBAMoperation(path_to_bam=input_path.as_posix(), callback=filter_method,
                                 callback_additional_args=[cutoff],
-                                n_processes=n_processes, output_path=output_path.as_posix())
+                                n_processes=n_processes, output_path=output_path.as_posix(),
+                                sort_by_name=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.21.2
 pysam==0.16.0.1
-parallelbam>=0.0.20
+parallel-bam>=0.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.21.2
 pysam==0.16.0.1
-parallel-bam>=0.0.20
+parallelbam-tools>=0.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.21.2
 pysam==0.16.0.1
-parallelbam==0.0.12
+parallelbam>=0.0.20

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name=NAME,
       download_url=DOWNLOAD_URL,
       license=LICENSE,
       packages=find_packages(),
-      install_requires=['numpy', 'pysam', 'parallelbam'],
+      install_requires=['numpy', 'pysam', 'parallelbam>=0.0.20'],
       entry_points ={
             'console_scripts': [
                 'filtersam = filtersam.cli:main'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), 'r', encoding='utf-8') as f:
 DESCRIPTION = 'Tools to filter sam o bam files by percent identity or percent of matched sequence'
 LONG_DESCRIPTION = long_description
 LONG_DESCRIPTION_CONTENT_TYPE = 'text/markdown'
-NAME = 'filtersam'
+NAME = 'filter-sam'
 AUTHOR = "Semidán Robaina Estévez, 2021-2022"
 AUTHOR_EMAIL = "srobaina@ull.edu.es"
 MAINTAINER = "Semidán Robaina Estévez"
@@ -32,7 +32,7 @@ setup(name=NAME,
       download_url=DOWNLOAD_URL,
       license=LICENSE,
       packages=find_packages(),
-      install_requires=['numpy', 'pysam', 'parallelbam>=0.0.20'],
+      install_requires=['numpy', 'pysam', 'parallel-bam>=0.0.20'],
       entry_points ={
             'console_scripts': [
                 'filtersam = filtersam.cli:main'

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), 'r', encoding='utf-8') as f:
 DESCRIPTION = 'Tools to filter sam o bam files by percent identity or percent of matched sequence'
 LONG_DESCRIPTION = long_description
 LONG_DESCRIPTION_CONTENT_TYPE = 'text/markdown'
-NAME = 'filter-sam'
+NAME = 'filtersam-tools'
 AUTHOR = "Semidán Robaina Estévez, 2021-2022"
 AUTHOR_EMAIL = "srobaina@ull.edu.es"
 MAINTAINER = "Semidán Robaina Estévez"
@@ -32,7 +32,7 @@ setup(name=NAME,
       download_url=DOWNLOAD_URL,
       license=LICENSE,
       packages=find_packages(),
-      install_requires=['numpy', 'pysam', 'parallel-bam>=0.0.20'],
+      install_requires=['numpy', 'pysam', 'parallelbam-tools>=0.0.20'],
       entry_points ={
             'console_scripts': [
                 'filtersam = filtersam.cli:main'


### PR DESCRIPTION
This PR does two related things needed to ship the parallel-mode speedup under the new PyPI account.

## 1. Performance: skip parallelbam's name-sort (closes #3)

Both filters evaluate each segment independently, so parallel chunks don't need reads grouped by query name. We pass `sort_by_name=False` to `parallelizeBAMoperation`, skipping the full serial `samtools sort -n` that made `-p` slower than single-processor mode. (Relies on the `sort_by_name` option in parallelBAM, Robaina/parallelBAM#3.)

## 2. Rename distribution to `filtersam-tools` + PyPI publishing

Re-publishing under a new PyPI account needs a new distribution name. `filtersam`/`filter-sam` are rejected (PyPI flags `filter-sam` as "too similar" to `filtersam`), so the new distribution is **`filtersam-tools`**. Import name unchanged (`import filtersam`); only `pip install` becomes `filtersam-tools`. Dependency renamed to **`parallelbam-tools>=0.0.20`** to match Robaina/parallelBAM#4.

- `setup.py`: `NAME` → `filtersam-tools`; dependency → `parallelbam-tools>=0.0.20`.
- `requirements.txt`: `parallelbam-tools>=0.0.20`.
- `pyproject.toml` (new): setuptools PEP 517 build backend.
- `.github/workflows/publish.yml` (new): build + publish to PyPI via **Trusted Publishing (OIDC)** on a published GitHub Release.
- `.github/workflows/tests.yml`: install parallelbam-tools from the parallelBAM repo without asserting the dist name (robust to the rename) until it is on PyPI.

## Required PyPI setup (one-time)

On https://pypi.org/manage/account/publishing/, add a pending publisher:
- Project: `filtersam-tools` · Owner: `Robaina` · Repo: `filterSAM` · Workflow: `publish.yml` · Environment: `pypi`

## Merge order

Merge Robaina/parallelBAM#4 (the `parallelbam-tools` rename) first, then this PR.

## Verification

Builds as `filtersam_tools-0.0.11` (`Requires-Dist: parallelbam-tools>=0.0.20`), `twine check` passes, full suite **32 passed** (incl. the end-to-end parallel run using `sort_by_name=False`).